### PR TITLE
refactor: Improve readability of regexes and fix warnings

### DIFF
--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,38 @@
+import pytest
+
+from user_image_classifier.main import (
+    _get_confidences,
+    _remove_confidence_substring,
+)
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("C99_myfile.jpg", (99, None)),
+        ("C99_foxes_C88_empty_myfile.jpg", (99, 88)),
+        ("C99_mountain_lions_C88_empty_myfile.jpg", (99, 88)),
+        ("C99_mountain-lions_C88_empty_myfile.jpg", (99, 88)),
+        ("myfile_C77.jpg", (77, None)),
+        ("myfile_C77_foxes_C66_empty.jpg", (77, 66)),
+        ("myfile.jpg", (None, None)),
+    ],
+)
+def test_get_confidences(filename, expected):
+    assert _get_confidences(filename) == expected
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("C99_myfile.jpg", "myfile.jpg"),
+        ("C99_foxes_C88_empty_myfile.jpg", "myfile.jpg"),
+        ("C99_mountain_lions_C88_empty_myfile.jpg", "myfile.jpg"),
+        ("C99_mountain-lions_C88_empty_myfile.jpg", "myfile.jpg"),
+        ("myfile_C77.jpg", "myfile.jpg"),
+        ("myfile_C77_foxes_C66_empty.jpg", "myfile.jpg"),
+        ("myfile.jpg", "myfile.jpg"),
+    ],
+)
+def test_remove_confidence_substring(filename, expected):
+    assert _remove_confidence_substring(filename) == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -195,3 +195,52 @@ def test_undo_after_abandon(mock_gui):
     assert len(gui.image_paths) == initial_image_count
     assert gui.image_paths[gui.current_index] == original_path
     assert gui.last_move is None
+
+
+@pytest.mark.parametrize(
+    ("min_confidence", "max_confidence", "use_secondary", "expected_images"),
+    [
+        (None, None, False, ["C50_a.jpg", "C80_fox_C20_bear_b.jpg", "c.jpg"]),
+        (60, None, False, ["C80_fox_C20_bear_b.jpg", "c.jpg"]),
+        (None, 60, False, ["C50_a.jpg", "c.jpg"]),
+        (None, None, True, ["C50_a.jpg", "C80_fox_C20_bear_b.jpg", "c.jpg"]),
+        (10, 30, True, ["C50_a.jpg", "C80_fox_C20_bear_b.jpg", "c.jpg"]),
+        (90, None, True, ["C50_a.jpg", "c.jpg"]),
+    ],
+)
+def test_confidence_filtering(tmp_path: Path, min_confidence, max_confidence, use_secondary, expected_images):
+    image_dir = tmp_path / "images"
+    image_dir.mkdir()
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+
+    image_paths = set()
+    for filename in ["C50_a.jpg", "C80_fox_C20_bear_b.jpg", "c.jpg"]:
+        p = image_dir / filename
+        p.touch()
+        image_paths.add(str(p))
+
+    with patch("tkinter.Tk"), patch("tkinter.Label"), patch("PIL.ImageTk.PhotoImage"), patch(
+        "PIL.Image.open"
+    ) as mock_open:
+        mock_image = MagicMock()
+        mock_image.size = (100, 100)
+        mock_image.resize.return_value = mock_image
+        mock_open.return_value = mock_image
+
+        root = MagicMock()
+        root.winfo_screenwidth.return_value = 800
+        root.winfo_screenheight.return_value = 600
+
+        gui = ImageClassifierGUI(
+            root,
+            image_paths,
+            {},
+            str(output_root),
+            min_confidence_threshold=min_confidence,
+            max_confidence_threshold=max_confidence,
+            use_secondary_confidence=use_secondary,
+        )
+
+        assert len(gui.image_paths) == len(expected_images)
+        assert {os.path.basename(p) for p in gui.image_paths} == set(expected_images)


### PR DESCRIPTION
This change refactors the regular expressions for parsing confidence scores to improve readability, as suggested by user feedback. It introduces substrings for confidence and class names, and composes the final regexes from these substrings.

This change also fixes a syntax warning related to invalid escape sequences in f-strings by using raw f-strings for the regex definitions.

Additionally, the class name matching has been made more robust by explicitly allowing hyphens, and a test case has been added to verify this.