### PR TITLE
feat: Increase bounding box label font size

### DIFF
--- a/src/user_image_classifier/main.py
+++ b/src/user_image_classifier/main.py
@@ -259,7 +259,13 @@ class ImageClassifierGUI:
 
             if bbox["label"]:
                 label_item = self.canvas.create_text(
-                    x1, y1 - 5, text=bbox["label"], fill=color, anchor=tk.SW, tags="bbox"
+                    x1,
+                    y1 - 5,
+                    text=bbox["label"],
+                    fill=color,
+                    anchor=tk.SW,
+                    tags="bbox",
+                    font=("Helvetica", 16),
                 )
                 bbox["label_item"] = label_item
                 text_bbox = self.canvas.bbox(label_item)


### PR DESCRIPTION
This commit increases the font size of the bounding box labels in the image classifier GUI. The font size is set to 16pt Helvetica, making the labels more readable.