### PR TITLE
feat: Add --edit flag to reload and edit existing classifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ extra-dependencies = [
 pythonpath = ["src"]
 
 [tool.hatch.envs.hatch-test]
+type = "virtual"
 extra-dependencies = [
     "pytest",
     "coverage",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,9 +48,9 @@ def test_find_sources(tmp_path: Path):
 
     # Expected files
     expected_files = {
-        Path(input_dir1 / "image1.jpg"),
-        Path(input_dir1_sub / "image2.jpeg"),
-        Path(input_dir2 / "image3.JPG"),
+        str(Path(input_dir1 / "image1.jpg")),
+        str(Path(input_dir1_sub / "image2.jpeg")),
+        str(Path(input_dir2 / "image3.JPG")),
     }
 
     # Run the function
@@ -72,7 +72,7 @@ def test_find_sources_skips_existing(tmp_path: Path):
     (input_dir / "image2.txt").touch()  # Pre-existing label for image2
 
     found_files = _find_sources([str(input_dir)])
-    assert found_files == {Path(input_dir / "image1.jpg")}
+    assert found_files == {str(Path(input_dir / "image1.jpg"))}
 
 
 def test_load_key_map_with_config_file(tmp_path: Path):


### PR DESCRIPTION
This commit introduces the `--edit` command-line flag, which allows users to edit previously classified images.

When the `--edit` flag is used, the application now loads images that already have an associated metadata file (.json or .txt). Upon opening an image, the existing bounding boxes are loaded, displayed on the canvas, and added to the undo stack, allowing for immediate editing.

The implementation includes:
- A new `--edit` argument in `main()`.
- Updated logic in `_find_sources()` to filter for classified images when in edit mode.
- New methods in `ImageClassifierGUI` (`_load_existing_metadata`, `_load_json_metadata`, `_load_yolo_metadata`) to handle the loading and parsing of both JSON and YOLO format metadata.

co-authored-by: erik.abair@gmail.com