### PR TITLE
Add --undo flag to renamer script

### DIFF
--- a/src/user_image_classifier/renamer.py
+++ b/src/user_image_classifier/renamer.py
@@ -73,6 +73,10 @@ def _get_class_counts(label_file: Path, class_map: dict[str, str]) -> str | None
     return "_".join(f"{count}{name}" for name, count in sorted(counts.items()))
 
 
+def _is_image_file(path: Path) -> bool:
+    return path.suffix.lower() in (".jpg", ".jpeg")
+
+
 def rename_files(
     input_dir: str,
     class_map: dict[str, str],
@@ -94,53 +98,96 @@ def rename_files(
     input_path = Path(input_dir)
     empty_dir = input_path / "empty"
 
-    for file_path in input_path.glob("*.*"):
-        if file_path.suffix.lower() not in (".jpg", ".jpeg"):
+    for image_path in input_path.glob("*.*"):
+        if not _is_image_file(image_path):
             continue
 
-        label_file = None
+        label_path = None
         for ext in (".txt", ".json"):
-            if (input_path / f"{file_path.stem}{ext}").exists():
-                label_file = input_path / f"{file_path.stem}{ext}"
+            if (input_path / f"{image_path.stem}{ext}").exists():
+                label_path = input_path / f"{image_path.stem}{ext}"
                 break
 
-        if not label_file:
-            print(f"⚠️  No label file found for {file_path.name}, skipping.")
+        if not label_path.is_file():
+            print(f"⚠️  No label file found for {image_path.name}, skipping.")
             continue
 
-        class_counts = _get_class_counts(label_file, class_map)
+        class_counts = _get_class_counts(label_path, class_map)
 
         if not class_counts:
             if remove_empty:
-                print(f"Removing empty file: {file_path.name}")
-                print(f"Removing empty label file: {label_file.name}")
+                print(f"Removing empty file: {image_path.name}")
+                print(f"Removing empty label file: {label_path.name}")
                 if not dry_run:
-                    os.remove(file_path)
-                    os.remove(label_file)
-            elif move_empty:
-                if not dry_run:
-                    empty_dir.mkdir(exist_ok=True)
-                print(f"Moving empty file: {file_path.name} to {empty_dir}")
-                print(f"Moving empty label file: {label_file.name} to {empty_dir}")
-                if not dry_run:
-                    os.rename(file_path, empty_dir / file_path.name)
-                    os.rename(label_file, empty_dir / label_file.name)
-            else:
-                class_counts = "unlabeled"
-
-        if class_counts:
-            timestamp = get_image_datetime(file_path)
-            if not timestamp:
-                print(f"⚠️  No EXIF date found for {file_path.name}, skipping.")
+                    os.remove(image_path)
+                    os.remove(label_path)
                 continue
 
-            new_filename = f"{timestamp}_{class_counts}--{file_path.name}"
-            new_image_path = input_path / new_filename
-            new_label_path = input_path / f"{new_image_path.stem}{label_file.suffix}"
+            if move_empty:
+                print(f"Moving empty file: {image_path.name} to {empty_dir}")
+                print(f"Moving empty label file: {label_path.name} to {empty_dir}")
+                if not dry_run:
+                    empty_dir.mkdir(exist_ok=True)
+                    os.rename(image_path, empty_dir / image_path.name)
+                    os.rename(label_path, empty_dir / label_path.name)
+                continue
 
-            print(f"Renaming '{file_path.name}' -> '{new_image_path.name}'")
-            print(f"Renaming '{label_file.name}' -> '{new_label_path.name}'")
+            class_counts = "unlabeled"
 
-            if not dry_run:
-                os.rename(file_path, new_image_path)
-                os.rename(label_file, new_label_path)
+        timestamp = get_image_datetime(image_path)
+        if not timestamp:
+            print(f"⚠️  No EXIF date found for {image_path.name}, skipping.")
+            continue
+
+        new_filename = f"{timestamp}_{class_counts}--{image_path.name}"
+        new_image_path = input_path / new_filename
+        new_label_path = input_path / f"{new_image_path.stem}{label_path.suffix}"
+
+        _perform_rename(image_path, new_image_path, label_path, new_label_path, dry_run=dry_run)
+
+
+def undo_rename(input_dir: str, *, dry_run: bool = False) -> None:
+    """
+    Reverts a previous renaming operation.
+
+    Args:
+        input_dir: The directory containing the files to rename.
+        dry_run: If True, print the changes without renaming files.
+    """
+    input_path = Path(input_dir)
+    for image_path in input_path.glob("*--*.*"):
+        if image_path.stem.count("--") != 1:
+            continue
+
+        if not _is_image_file(image_path):
+            continue
+
+        original_filename = image_path.name.split("--", 1)[1]
+        new_image_path = input_path / original_filename
+
+        label_path = None
+        for ext in (".txt", ".json"):
+            # The label file would have been renamed to match the image file (without the image extension)
+            potential_label_name = f"{image_path.stem}{ext}"
+            if (input_path / potential_label_name).exists():
+                label_path = input_path / potential_label_name
+                break
+
+        if not label_path:
+            print(f"⚠️  No label file found for {image_path.name}, skipping.")
+            continue
+
+        new_label_path = input_path / f"{new_image_path.stem}{label_path.suffix}"
+
+        _perform_rename(image_path, new_image_path, label_path, new_label_path, dry_run=dry_run)
+
+
+def _perform_rename(
+    image_path: Path, new_image_path: Path, label_path: Path, new_label_path: Path, *, dry_run: bool
+) -> None:
+    print(f"Renaming '{image_path.name}' -> '{new_image_path.name}'")
+    print(f"Renaming '{label_path.name}' -> '{new_label_path.name}'")
+
+    if not dry_run:
+        os.rename(image_path, new_image_path)
+        os.rename(label_path, new_label_path)

--- a/src/user_image_classifier/renamer_cli.py
+++ b/src/user_image_classifier/renamer_cli.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 
 from user_image_classifier.config import load_key_map
-from user_image_classifier.renamer import rename_files
+from user_image_classifier.renamer import rename_files, undo_rename
 
 
 def main() -> int:
@@ -37,17 +37,25 @@ def main() -> int:
         action="store_true",
         help="Move files with no labels to a new 'empty' directory.",
     )
+    group.add_argument(
+        "--undo",
+        action="store_true",
+        help="Attempts to detect and remove previous runs of the script.",
+    )
 
     args = parser.parse_args()
-    key_map = load_key_map(args.config)
 
-    rename_files(
-        args.dir,
-        key_map,
-        dry_run=args.dry_run,
-        remove_empty=args.remove_empty,
-        move_empty=args.move_empty,
-    )
+    if args.undo:
+        undo_rename(args.dir, dry_run=args.dry_run)
+    else:
+        key_map = load_key_map(args.config)
+        rename_files(
+            args.dir,
+            key_map,
+            dry_run=args.dry_run,
+            remove_empty=args.remove_empty,
+            move_empty=args.move_empty,
+        )
     return 0
 
 

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+# ruff: noqa: DTZ001 `datetime.datetime()` called without a `tzinfo` argument
+from datetime import datetime
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from user_image_classifier.renamer import rename_files, undo_rename
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_rename_and_undo(tmp_path: Path):
+    # 1. Setup: Create dummy files
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+
+    # Create dummy image file
+    image_path = input_dir / "test_image.jpg"
+    image_path.touch()
+
+    # Create dummy label file
+    label_path = input_dir / "test_image.txt"
+    with open(label_path, "w") as f:
+        f.write("0 0.5 0.5 0.1 0.1\n")  # class 0
+
+    class_map = {"0": "cat", "1": "dog"}
+
+    # Mock get_image_datetime to return a fixed timestamp
+    mock_datetime = datetime(2025, 1, 1, 12, 0, 0)
+
+    # 2. Run rename_files
+    with patch("user_image_classifier.renamer.get_image_datetime", return_value=mock_datetime):
+        rename_files(str(input_dir), class_map)
+
+    # 3. Assert rename_files results
+    expected_new_filename_stem = f"{mock_datetime}_1cat--test_image"
+    renamed_image_path = input_dir / f"{expected_new_filename_stem}.jpg"
+    renamed_label_path = input_dir / f"{expected_new_filename_stem}.txt"
+
+    assert renamed_image_path.exists()
+    assert renamed_label_path.exists()
+    assert not image_path.exists()
+    assert not label_path.exists()
+
+    # 4. Run undo_rename
+    undo_rename(str(input_dir))
+
+    # 5. Assert undo_rename results
+    assert image_path.exists()
+    assert label_path.exists()
+    assert not renamed_image_path.exists()
+    assert not renamed_label_path.exists()


### PR DESCRIPTION
This commit introduces an `--undo` flag to the renamer script. This new functionality allows users to revert the file renaming operations performed by the script.

The changes include:
- A new `undo_rename` function in `renamer.py` that identifies files renamed by the script (using the `--` separator) and restores their original names.
- An `--undo` argument in `renamer_cli.py` to trigger the undo operation.
- A new test file `tests/test_renamer.py` with a test case to verify the undo functionality.

co-authored-by: erik.abair@gmail.com