### PR TITLE
feat: Add imgclassify-cleanup script to remove duplicate images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ Source = "https://github.com/abaire/user-image-classifier"
 [project.scripts]
 imgclassifier = "user_image_classifier:run"
 imgclassify-rename = "user_image_classifier.renamer_cli:main"
+imgclassify-cleanup = "user_image_classifier.cleanup_cli:main"
 
 [tool.hatch.version]
 path = "src/user_image_classifier/__about__.py"

--- a/src/user_image_classifier/cleanup.py
+++ b/src/user_image_classifier/cleanup.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+# ruff: noqa: T201 `print` found
+import hashlib
+import itertools
+import os
+from pathlib import Path
+
+SUPPORTED_FORMATS = {"jpg", "jpeg"}
+
+
+def _calculate_hash(filepath: str) -> str:
+    """Calculates the SHA256 hash of a file."""
+    hasher = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        while chunk := f.read(4096):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def cleanup_images(
+    input_dirs: list[str],
+    *,
+    dry_run: bool = False,
+) -> list[str]:
+    """
+    Finds and removes duplicate images from the given directories.
+
+    Args:
+        input_dirs: A list of directories to search for images.
+        dry_run: If True, prints the actions that would be taken without
+                 actually deleting any files.
+
+    Returns:
+        A list of file paths that were (or would be) deleted.
+    """
+    input_dirs = [Path(os.path.expanduser(input_dir)) for input_dir in input_dirs]
+    all_files = itertools.chain.from_iterable(base_path.rglob("*.*") for base_path in input_dirs)
+
+    seen_hashes = {}
+    deleted_files = []
+
+    for file_path in sorted(all_files):
+        if not file_path.is_file() or file_path.suffix[1:].lower() not in SUPPORTED_FORMATS:
+            continue
+
+        str_path = str(file_path)
+        file_hash = _calculate_hash(str_path)
+
+        if file_hash in seen_hashes:
+            if dry_run:
+                print(f"Would delete '{str_path}' (duplicate of '{seen_hashes[file_hash]}')")
+            else:
+                print(f"Deleting '{str_path}' (duplicate of '{seen_hashes[file_hash]}')")
+                os.remove(str_path)
+            deleted_files.append(str_path)
+        else:
+            seen_hashes[file_hash] = str_path
+
+    return deleted_files

--- a/src/user_image_classifier/cleanup_cli.py
+++ b/src/user_image_classifier/cleanup_cli.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+# ruff: noqa: T201 `print` found
+import argparse
+import sys
+
+from user_image_classifier.cleanup import cleanup_images
+
+
+def main() -> int:
+    """
+    Main function to parse arguments and run the cleanup script.
+    """
+    parser = argparse.ArgumentParser(
+        description="A utility to find and remove duplicate images.",
+    )
+    parser.add_argument(
+        "-d",
+        "--dirs",
+        nargs="+",
+        required=True,
+        help="One or more source directories to search for JPGs recursively.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the changes without deleting files.",
+    )
+
+    args = parser.parse_args()
+
+    deleted_files = cleanup_images(args.dirs, dry_run=args.dry_run)
+
+    if deleted_files:
+        print(f"\n{len(deleted_files)} duplicate files found.")
+    else:
+        print("No duplicate files found.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PIL import Image
+
+from user_image_classifier.cleanup import cleanup_images
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def create_dummy_image(path: Path, size: tuple[int, int] = (10, 10)):
+    """Creates a dummy image file."""
+    img = Image.new("RGB", size, color="red")
+    img.save(path, "JPEG")
+
+
+def test_cleanup_images_dry_run(tmp_path: Path):
+    """
+    Tests that cleanup_images with dry_run=True identifies but does not
+    delete duplicate files.
+    """
+    # 1. Setup: Create dummy files and duplicates
+    dir1 = tmp_path / "dir1"
+    dir1.mkdir()
+    dir2 = tmp_path / "dir2"
+    dir2.mkdir()
+
+    image_path1 = dir1 / "image1.jpg"
+    image_path2 = dir2 / "image2.jpg"
+    image_path3 = dir1 / "image3.jpg"  # a different image
+
+    create_dummy_image(image_path1)
+    create_dummy_image(image_path2)
+    create_dummy_image(image_path3, size=(5, 5))
+
+    # 2. Run cleanup_images with dry_run
+    deleted_files = cleanup_images([str(tmp_path)], dry_run=True)
+
+    # 3. Assert results
+    assert len(deleted_files) == 1
+    assert str(image_path2) in deleted_files
+    assert image_path1.exists()
+    assert image_path2.exists()
+    assert image_path3.exists()
+
+
+def test_cleanup_images_deletes_duplicates(tmp_path: Path):
+    """
+    Tests that cleanup_images correctly identifies and deletes duplicate files.
+    """
+    # 1. Setup: Create dummy files and duplicates
+    dir1 = tmp_path / "dir1"
+    dir1.mkdir()
+    dir2 = tmp_path / "dir2"
+    dir2.mkdir()
+
+    image_path1 = dir1 / "image1.jpg"
+    image_path2 = dir2 / "image2.jpg"
+    image_path3 = dir1 / "image3.jpg"  # a different image
+
+    create_dummy_image(image_path1)
+    create_dummy_image(image_path2)
+    create_dummy_image(image_path3, size=(5, 5))
+
+    # 2. Run cleanup_images
+    deleted_files = cleanup_images([str(tmp_path)], dry_run=False)
+
+    # 3. Assert results
+    assert len(deleted_files) == 1
+    assert str(image_path2) in deleted_files
+    assert image_path1.exists()
+    assert not image_path2.exists()
+    assert image_path3.exists()


### PR DESCRIPTION
This commit introduces a new script `imgclassify-cleanup` that finds and removes duplicate images from specified directories.

The script identifies duplicates by comparing the SHA256 hash of image files. It supports a `--dry-run` mode to preview the changes before deleting any files.

The changes include:
- A new `cleanup.py` module with the core logic.
- A `cleanup_cli.py` module for the command-line interface.
- An entry for the new script in `pyproject.toml`.
- Unit tests for the new functionality.