### PR TITLE
Removes YOLO and adds fixup mode.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Setup commands
+- Install hatch: see https://hatch.pypa.io/1.13/install/
+- Run tests: `hatch test`
+
+## Code style
+- Use `hatch fmt` to format code.
+- Assume the reader is an expert Python programmer and omit obvious comments.
+- Please examine previous git commit messages and use a similar style. E.g., "Adds foo feature."
+- Use type annotations wherever possible


### PR DESCRIPTION
This commit removes all code related to the YOLO format, as it is no longer in use. This includes the `--yolo` command-line argument, all associated functions for loading and saving YOLO-formatted data, and related tests.

This commit also finalizes the implementation of the `--fixup` mode, which allows for correcting inferences from other tools. The `--fixup` mode is now mutually exclusive with the `--edit` mode. When in fixup mode, the application will read metadata (including a `confidence` field), allow the user to make corrections, and then save the image and the corrected metadata to a specified output directory. The `confidence` field is stripped from the metadata upon saving.